### PR TITLE
Revert "Change in tests "Altom" name in imports for C# package"

### DIFF
--- a/TestAlttrashCSharp/pages/BasePage.cs
+++ b/TestAlttrashCSharp/pages/BasePage.cs
@@ -1,4 +1,4 @@
-using AltTester.AltDriver;
+using Altom.AltDriver;
 
 namespace alttrashcat_tests_csharp.pages
 {

--- a/TestAlttrashCSharp/pages/GamePlay.cs
+++ b/TestAlttrashCSharp/pages/GamePlay.cs
@@ -1,5 +1,5 @@
+using Altom.AltDriver;
 using System;
-using AltTester.AltDriver;
 
 namespace alttrashcat_tests_csharp.pages
 {

--- a/TestAlttrashCSharp/pages/GetAnotherChancePage.cs
+++ b/TestAlttrashCSharp/pages/GetAnotherChancePage.cs
@@ -1,4 +1,4 @@
-using AltTester.AltDriver;
+using Altom.AltDriver;
 
 namespace alttrashcat_tests_csharp.pages
 {

--- a/TestAlttrashCSharp/pages/MainMenuPage.cs
+++ b/TestAlttrashCSharp/pages/MainMenuPage.cs
@@ -1,4 +1,4 @@
-using AltTester.AltDriver;
+using Altom.AltDriver;
 
 namespace alttrashcat_tests_csharp.pages
 {

--- a/TestAlttrashCSharp/pages/PauseOverlayPage.cs
+++ b/TestAlttrashCSharp/pages/PauseOverlayPage.cs
@@ -1,4 +1,4 @@
-using AltTester.AltDriver;
+using Altom.AltDriver;
 
 namespace alttrashcat_tests_csharp.pages
 {

--- a/TestAlttrashCSharp/pages/StartPage.cs
+++ b/TestAlttrashCSharp/pages/StartPage.cs
@@ -1,4 +1,4 @@
-using AltTester.AltDriver;
+using Altom.AltDriver;
 
 namespace alttrashcat_tests_csharp.pages
 {

--- a/TestAlttrashCSharp/tests/GamePlayTests.cs
+++ b/TestAlttrashCSharp/tests/GamePlayTests.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Threading;
-using AltTester.AltDriver;
+using Altom.AltDriver;
 using alttrashcat_tests_csharp.pages;
 using NUnit.Framework;
 

--- a/TestAlttrashCSharp/tests/MainMenuTests.cs
+++ b/TestAlttrashCSharp/tests/MainMenuTests.cs
@@ -1,7 +1,7 @@
+using Altom.AltDriver;
+using alttrashcat_tests_csharp.pages;
 using System;
 using System.Threading;
-using AltTester.AltDriver;
-using alttrashcat_tests_csharp.pages;
 using NUnit.Framework;
 namespace alttrashcat_tests_csharp.tests
 {

--- a/TestAlttrashCSharp/tests/StartPageTests.cs
+++ b/TestAlttrashCSharp/tests/StartPageTests.cs
@@ -1,7 +1,7 @@
+using Altom.AltDriver;
+using alttrashcat_tests_csharp.pages;
 using System;
 using System.Threading;
-using AltTester.AltDriver;
-using alttrashcat_tests_csharp.pages;
 using NUnit.Framework;
 
 namespace alttrashcat_tests_csharp.tests


### PR DESCRIPTION
Reverts alttester/EXAMPLES-CSharp-Standalone-AltTrashCat#4