### PR TITLE
Revert "Revert "Change in tests "Altom" name in imports for C# package""

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,19 @@ Create a folder `App` under project.
 
 To start the tests, depending of your OS run:
 
-- `./start_tests_Mac.sh` on MacOS/Linux
-
-    Create a folder `TrashCatMac` under `App`.
+- **MacOS**:
+    1. Instal the [AltTesterDesktop](https://alttester.com/app/uploads/AltTester/desktop/AltTesterDesktopPackageMac__v2.0.1.zip), then open it.
+    2. Create a folder `TrashCatMac` under `App`.
     The app is provided at https://altom.com/app/uploads/AltTester/TrashCat/TrashCatMacOS.app.zip and needs to be included unzipped under the App/TrashCatMac/ folder.
+    3. run `./start_tests_Mac.sh` in your bash terminal.
 
-- `./start_tests_Windows.sh` on Windows
+- **Windows**:
+    1. Instal the [AltTesterDesktop](https://alttester.com/app/uploads/AltTester/desktop/AltTesterDesktopPackageMac__v2.0.1.zip), then open it.
+    2. Create a folder `TrashCatWindows` under `App`.
+    The app is provided at https://alttester.com/app/uploads/AltTester/TrashCat/TrashCatStandAlone2_0_1.zip and needs to be included unzipped under the App/TrashCatWindows/ folder.
+    3. run `./start_tests_Windows.sh` in your bash terminal
 
-    Create a folder `TrashCatWindows` under `App`.
-    The app is provided at https://altom.com/app/uploads/AltTester/TrashCat/TrashCatWindows.zip and needs to be included unzipped under the App/TrashCatWindows/ folder.
+    
     
 This script will:
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To start the tests, depending of your OS run:
 - **MacOS**:
     1. Install the [AltTesterDesktop](https://alttester.com/app/uploads/AltTester/desktop/AltTesterDesktopPackageMac__v2.0.1.zip), then open it.
     2. Create a folder `TrashCatMac` under `App`.
-    The app is provided at https://altom.com/app/uploads/AltTester/TrashCat/TrashCatMacOS.app.zip and needs to be included unzipped under the App/TrashCatMac/ folder.
+    The app is provided at https://alttester.com/app/uploads/AltTester/TrashCat/TrashCat.app.zip and needs to be included unzipped under the App/TrashCatMac/ folder.
     3. run `./start_tests_Mac.sh` in your bash terminal.
 
 - **Windows**:

--- a/README.md
+++ b/README.md
@@ -13,14 +13,15 @@ Create a folder `App` under project.
 
 To start the tests, depending of your OS run:
 
+❗ Starting with version 2.0.0, the AltTester Desktop must be running on your PC while the tests are running.
 - **MacOS**:
-    1. Instal the [AltTesterDesktop](https://alttester.com/app/uploads/AltTester/desktop/AltTesterDesktopPackageMac__v2.0.1.zip), then open it.
+    1. Install the [AltTesterDesktop](https://alttester.com/app/uploads/AltTester/desktop/AltTesterDesktopPackageMac__v2.0.1.zip), then open it.
     2. Create a folder `TrashCatMac` under `App`.
     The app is provided at https://altom.com/app/uploads/AltTester/TrashCat/TrashCatMacOS.app.zip and needs to be included unzipped under the App/TrashCatMac/ folder.
     3. run `./start_tests_Mac.sh` in your bash terminal.
 
 - **Windows**:
-    1. Instal the [AltTesterDesktop](https://alttester.com/app/uploads/AltTester/desktop/AltTesterDesktopPackageMac__v2.0.1.zip), then open it.
+    1. Install the [AltTesterDesktop](https://alttester.com/app/uploads/AltTester/desktop/AltTesterDesktopPackageWindows__v2.0.1.zip), then open it.
     2. Create a folder `TrashCatWindows` under `App`.
     The app is provided at https://alttester.com/app/uploads/AltTester/TrashCat/TrashCatStandAlone2_0_1.zip and needs to be included unzipped under the App/TrashCatWindows/ folder.
     3. run `./start_tests_Windows.sh` in your bash terminal

--- a/TestAlttrashCSharp/TestAlttrashCSharp.csproj
+++ b/TestAlttrashCSharp/TestAlttrashCSharp.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp7</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AltTester-Driver" Version="1.8.0" />
+    <PackageReference Include="AltTester-Driver" Version="2.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Unity3D.UnityEngine" Version="2018.3.5.1" />
     <PackageReference Include="nunit" Version="3.12.0" />

--- a/TestAlttrashCSharp/pages/BasePage.cs
+++ b/TestAlttrashCSharp/pages/BasePage.cs
@@ -1,4 +1,4 @@
-using Altom.AltDriver;
+using AltTester.AltDriver;
 
 namespace alttrashcat_tests_csharp.pages
 {

--- a/TestAlttrashCSharp/pages/BasePage.cs
+++ b/TestAlttrashCSharp/pages/BasePage.cs
@@ -1,4 +1,4 @@
-using AltTester.AltDriver;
+using AltTester.AltTesterUnitySDK.Driver;
 
 namespace alttrashcat_tests_csharp.pages
 {

--- a/TestAlttrashCSharp/pages/GamePlay.cs
+++ b/TestAlttrashCSharp/pages/GamePlay.cs
@@ -1,5 +1,5 @@
-using Altom.AltDriver;
 using System;
+using AltTester.AltDriver;
 
 namespace alttrashcat_tests_csharp.pages
 {

--- a/TestAlttrashCSharp/pages/GamePlay.cs
+++ b/TestAlttrashCSharp/pages/GamePlay.cs
@@ -1,5 +1,5 @@
 using System;
-using AltTester.AltDriver;
+using AltTester.AltTesterUnitySDK.Driver;
 
 namespace alttrashcat_tests_csharp.pages
 {

--- a/TestAlttrashCSharp/pages/GetAnotherChancePage.cs
+++ b/TestAlttrashCSharp/pages/GetAnotherChancePage.cs
@@ -1,4 +1,4 @@
-using Altom.AltDriver;
+using AltTester.AltDriver;
 
 namespace alttrashcat_tests_csharp.pages
 {

--- a/TestAlttrashCSharp/pages/GetAnotherChancePage.cs
+++ b/TestAlttrashCSharp/pages/GetAnotherChancePage.cs
@@ -1,4 +1,4 @@
-using AltTester.AltDriver;
+using AltTester.AltTesterUnitySDK.Driver;
 
 namespace alttrashcat_tests_csharp.pages
 {

--- a/TestAlttrashCSharp/pages/MainMenuPage.cs
+++ b/TestAlttrashCSharp/pages/MainMenuPage.cs
@@ -1,4 +1,4 @@
-using Altom.AltDriver;
+using AltTester.AltDriver;
 
 namespace alttrashcat_tests_csharp.pages
 {

--- a/TestAlttrashCSharp/pages/MainMenuPage.cs
+++ b/TestAlttrashCSharp/pages/MainMenuPage.cs
@@ -1,4 +1,4 @@
-using AltTester.AltDriver;
+using AltTester.AltTesterUnitySDK.Driver;
 
 namespace alttrashcat_tests_csharp.pages
 {

--- a/TestAlttrashCSharp/pages/PauseOverlayPage.cs
+++ b/TestAlttrashCSharp/pages/PauseOverlayPage.cs
@@ -1,4 +1,4 @@
-using Altom.AltDriver;
+using AltTester.AltDriver;
 
 namespace alttrashcat_tests_csharp.pages
 {

--- a/TestAlttrashCSharp/pages/PauseOverlayPage.cs
+++ b/TestAlttrashCSharp/pages/PauseOverlayPage.cs
@@ -1,4 +1,4 @@
-using AltTester.AltDriver;
+using AltTester.AltTesterUnitySDK.Driver;
 
 namespace alttrashcat_tests_csharp.pages
 {

--- a/TestAlttrashCSharp/pages/StartPage.cs
+++ b/TestAlttrashCSharp/pages/StartPage.cs
@@ -1,4 +1,4 @@
-using Altom.AltDriver;
+using AltTester.AltDriver;
 
 namespace alttrashcat_tests_csharp.pages
 {

--- a/TestAlttrashCSharp/pages/StartPage.cs
+++ b/TestAlttrashCSharp/pages/StartPage.cs
@@ -1,4 +1,4 @@
-using AltTester.AltDriver;
+using AltTester.AltTesterUnitySDK.Driver;
 
 namespace alttrashcat_tests_csharp.pages
 {

--- a/TestAlttrashCSharp/tests/GamePlayTests.cs
+++ b/TestAlttrashCSharp/tests/GamePlayTests.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Threading;
-using Altom.AltDriver;
+using AltTester.AltDriver;
 using alttrashcat_tests_csharp.pages;
 using NUnit.Framework;
 

--- a/TestAlttrashCSharp/tests/GamePlayTests.cs
+++ b/TestAlttrashCSharp/tests/GamePlayTests.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Threading;
-using AltTester.AltDriver;
+using AltTester.AltTesterUnitySDK.Driver;
 using alttrashcat_tests_csharp.pages;
 using NUnit.Framework;
 

--- a/TestAlttrashCSharp/tests/MainMenuTests.cs
+++ b/TestAlttrashCSharp/tests/MainMenuTests.cs
@@ -1,7 +1,7 @@
-using Altom.AltDriver;
-using alttrashcat_tests_csharp.pages;
 using System;
 using System.Threading;
+using AltTester.AltDriver;
+using alttrashcat_tests_csharp.pages;
 using NUnit.Framework;
 namespace alttrashcat_tests_csharp.tests
 {

--- a/TestAlttrashCSharp/tests/MainMenuTests.cs
+++ b/TestAlttrashCSharp/tests/MainMenuTests.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Threading;
-using AltTester.AltDriver;
+using AltTester.AltTesterUnitySDK.Driver;
 using alttrashcat_tests_csharp.pages;
 using NUnit.Framework;
 namespace alttrashcat_tests_csharp.tests

--- a/TestAlttrashCSharp/tests/StartPageTests.cs
+++ b/TestAlttrashCSharp/tests/StartPageTests.cs
@@ -1,7 +1,7 @@
-using Altom.AltDriver;
-using alttrashcat_tests_csharp.pages;
 using System;
 using System.Threading;
+using AltTester.AltDriver;
+using alttrashcat_tests_csharp.pages;
 using NUnit.Framework;
 
 namespace alttrashcat_tests_csharp.tests

--- a/TestAlttrashCSharp/tests/StartPageTests.cs
+++ b/TestAlttrashCSharp/tests/StartPageTests.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Threading;
-using AltTester.AltDriver;
+using AltTester.AltTesterUnitySDK.Driver;
 using alttrashcat_tests_csharp.pages;
 using NUnit.Framework;
 

--- a/alttrashcat-tests-csharp.csproj
+++ b/alttrashcat-tests-csharp.csproj
@@ -2,14 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp7</TargetFramework>
     <RootNamespace>alttrashcat_tests_csharp</RootNamespace>
     <ApplicationIcon />
     <StartupObject />
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AltTester-Driver" Version="1.8.0" />
+    <PackageReference Include="AltTester-Driver" Version="2.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="nunit" Version="3.12.0" />

--- a/start_tests_Windows.sh
+++ b/start_tests_Windows.sh
@@ -1,5 +1,9 @@
+# echo "==> Start AltTester Desktop"
+# start "" "AltTester Desktop\AltTesterDesktop.exe"
+# echo "==> Wait for AltTesterDesktop to start"
+# sleep 5
+# waiting for clarifications about the terms and conditions 
 echo "==> Start application"
-
 start "" "App\TrashCatWindows\TrashCat.exe"
 
 echo "==> Wait for app to start"
@@ -12,3 +16,5 @@ dotnet test  -- NUnit.TestOutputXml = "TestAlttrashCSharp"
 echo "==> Kill app"
 taskkill //PID $(tasklist | grep TrashCat.exe | awk '{print $2}') //T //F
 
+# echo "==> Kill app"
+# taskkill //PID $(tasklist | grep AltTesterDesktop.exe | awk '{print $2}') //T //F

--- a/start_tests_Windows.sh
+++ b/start_tests_Windows.sh
@@ -1,8 +1,3 @@
-# echo "==> Start AltTester Desktop"
-# start "" "AltTester Desktop\AltTesterDesktop.exe"
-# echo "==> Wait for AltTesterDesktop to start"
-# sleep 5
-# waiting for clarifications about the terms and conditions 
 echo "==> Start application"
 start "" "App\TrashCatWindows\TrashCat.exe"
 
@@ -15,6 +10,3 @@ dotnet test  -- NUnit.TestOutputXml = "TestAlttrashCSharp"
 
 echo "==> Kill app"
 taskkill //PID $(tasklist | grep TrashCat.exe | awk '{print $2}') //T //F
-
-# echo "==> Kill app"
-# taskkill //PID $(tasklist | grep AltTesterDesktop.exe | awk '{print $2}') //T //F


### PR DESCRIPTION
Reverts alttester/EXAMPLES-CSharp-Standalone-AltTrashCat#5

In this PR will be done:

- Change in tests "Altom" name in imports for C# package
- Update the builds and the readme (with changes from 2.0.1)
- The driver will pe updated to 2.0.1
- The dotnet will be updated to 7